### PR TITLE
[TASK] Align with new TYPO3 documentation standards

### DIFF
--- a/resources/templates/Default/Root.rst
+++ b/resources/templates/Default/Root.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _start:
 

--- a/resources/templates/Default/Schema.rst
+++ b/resources/templates/Default/Schema.rst
@@ -1,4 +1,4 @@
-.. include:: {rootPath}Includes.txt
+.. include:: /Includes.rst.txt
 
 {headlineDecoration}
 {headline}

--- a/resources/templates/Default/ViewHelper.rst
+++ b/resources/templates/Default/ViewHelper.rst
@@ -18,6 +18,7 @@ Arguments
 
 <f:for each="{arguments}" as="argumentData">
 .. _{argumentData.headlineIdentifier}:
+
 {argumentData.headline}
 {argumentData.headlineDecoration}
 <f:if condition="{argumentData.dataType}">

--- a/resources/templates/Default/ViewHelper.rst
+++ b/resources/templates/Default/ViewHelper.rst
@@ -1,4 +1,4 @@
-.. include:: {rootPath}Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _{headlineIdentifier}:
 

--- a/resources/templates/Default/ViewHelperGroup.rst
+++ b/resources/templates/Default/ViewHelperGroup.rst
@@ -1,4 +1,4 @@
-.. include:: {rootPath}Includes.txt
+.. include:: /Includes.rst.txt
 
 {headlineDecoration}
 {headline}

--- a/tests/Fixtures/rendering/output/Documentation/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/Index.rst
@@ -1,4 +1,4 @@
-.. include:: Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============================
 Fluid ViewHelper Documentation

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Avatar.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Avatar.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ======
 avatar

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =============
 typo3/backend

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _typo3-backend-link-editrecord:
 

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
@@ -29,6 +29,7 @@ Arguments
 
 
 .. _link.editrecord_additionalattributes:
+
 additionalAttributes
 --------------------
 
@@ -41,6 +42,7 @@ additionalAttributes
    Additional tag attributes. They will be added directly to the resulting HTML tag.
 
 .. _link.editrecord_data:
+
 data
 ----
 
@@ -53,6 +55,7 @@ data
    Additional data-* attributes. They will each be added with a "data-" prefix.
 
 .. _link.editrecord_class:
+
 class
 -----
 
@@ -65,6 +68,7 @@ class
    CSS class(es) for this element
 
 .. _link.editrecord_dir:
+
 dir
 ---
 
@@ -77,6 +81,7 @@ dir
    Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)
 
 .. _link.editrecord_id:
+
 id
 --
 
@@ -89,6 +94,7 @@ id
    Unique (in this file) identifier for this HTML element.
 
 .. _link.editrecord_lang:
+
 lang
 ----
 
@@ -101,6 +107,7 @@ lang
    Language for this element. Use short names specified in RFC 1766
 
 .. _link.editrecord_style:
+
 style
 -----
 
@@ -113,6 +120,7 @@ style
    Individual CSS styles for this element
 
 .. _link.editrecord_title:
+
 title
 -----
 
@@ -125,6 +133,7 @@ title
    Tooltip text of element
 
 .. _link.editrecord_accesskey:
+
 accesskey
 ---------
 
@@ -137,6 +146,7 @@ accesskey
    Keyboard shortcut to access this element
 
 .. _link.editrecord_tabindex:
+
 tabindex
 --------
 
@@ -149,6 +159,7 @@ tabindex
    Specifies the tab order of this element
 
 .. _link.editrecord_onclick:
+
 onclick
 -------
 
@@ -161,6 +172,7 @@ onclick
    JavaScript evaluated for the onclick event
 
 .. _link.editrecord_uid:
+
 uid
 ---
 
@@ -173,6 +185,7 @@ uid
    Uid of record to be edited
 
 .. _link.editrecord_table:
+
 table
 -----
 
@@ -185,6 +198,7 @@ table
    Target database table
 
 .. _link.editrecord_returnurl:
+
 returnUrl
 ---------
 

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ====
 link

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/NewRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/NewRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============
 link.newRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ============
 moduleLayout

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ======
 button

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/LinkButton.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/LinkButton.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============================
 moduleLayout.button.linkButton

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/ShortcutButton.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Button/ShortcutButton.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==================================
 moduleLayout.button.shortcutButton

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ============
 moduleLayout

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Menu.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/Menu.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =================
 moduleLayout.menu

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/MenuItem.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLayout/MenuItem.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =====================
 moduleLayout.menuItem

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 .. _typo3-backend-modulelink:
 

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
@@ -14,6 +14,7 @@ Arguments
 
 
 .. _modulelink_route:
+
 route
 -----
 
@@ -26,6 +27,7 @@ route
    The route to link to
 
 .. _modulelink_arguments:
+
 arguments
 ---------
 
@@ -41,6 +43,7 @@ arguments
    Additional link arguments
 
 .. _modulelink_query:
+
 query
 -----
 
@@ -53,6 +56,7 @@ query
    Additional link arguments as string
 
 .. _modulelink_currenturlparametername:
+
 currentUrlParameterName
 -----------------------
 

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/EditRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============
 uri.editRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ===
 uri

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/NewRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Uri/NewRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =============
 uri.newRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Avatar.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Avatar.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ======
 avatar

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =============
 typo3/backend

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/EditRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ===============
 link.editRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ====
 link

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/NewRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Link/NewRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============
 link.newRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ============
 moduleLayout

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ======
 button

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/LinkButton.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/LinkButton.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============================
 moduleLayout.button.linkButton

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/ShortcutButton.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Button/ShortcutButton.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==================================
 moduleLayout.button.shortcutButton

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ============
 moduleLayout

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Menu.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/Menu.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =================
 moduleLayout.menu

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/MenuItem.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLayout/MenuItem.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =====================
 moduleLayout.menuItem

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLink.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/ModuleLink.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==========
 moduleLink

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/EditRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ==============
 uri.editRecord

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/Index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 ===
 uri

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/NewRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.5/Uri/NewRecord.rst
@@ -1,4 +1,4 @@
-.. include:: ../../../../Includes.txt
+.. include:: /Includes.rst.txt
 
 =============
 uri.newRecord

--- a/tests/Functional/RstRendering/IndexForSchemaTest.php
+++ b/tests/Functional/RstRendering/IndexForSchemaTest.php
@@ -68,7 +68,7 @@ class IndexForSchemaTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: ../../../Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**

--- a/tests/Functional/RstRendering/IndexForViewhelperGroupWithSubGroupsTest.php
+++ b/tests/Functional/RstRendering/IndexForViewhelperGroupWithSubGroupsTest.php
@@ -68,7 +68,7 @@ class IndexForViewhelperGroupWithSubGroupsTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: ../../../../Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**

--- a/tests/Functional/RstRendering/IndexForViewhelperGroupWithoutSubGroupsTest.php
+++ b/tests/Functional/RstRendering/IndexForViewhelperGroupWithoutSubGroupsTest.php
@@ -68,7 +68,7 @@ class IndexForViewhelperGroupWithoutSubGroupsTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: ../../../../Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**

--- a/tests/Functional/RstRendering/RootIndexFileTest.php
+++ b/tests/Functional/RstRendering/RootIndexFileTest.php
@@ -52,7 +52,7 @@ class RootIndexFileTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**

--- a/tests/Functional/RstRendering/ViewHelperFileFirstLevelTest.php
+++ b/tests/Functional/RstRendering/ViewHelperFileFirstLevelTest.php
@@ -69,7 +69,7 @@ class ViewHelperFileFirstLevelTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: ../../../Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**

--- a/tests/Functional/RstRendering/ViewHelperFileSecondLevelTest.php
+++ b/tests/Functional/RstRendering/ViewHelperFileSecondLevelTest.php
@@ -69,7 +69,7 @@ class ViewHelperFileSecondLevelTest extends TestCase
     public function includeClausePointsToSettingsCfg()
     {
         $output = file($this->vfs->getChild($this->generatedFilePath)->url());
-        $this->assertSame('.. include:: ../../../../Includes.txt' . PHP_EOL, $output[0]);
+        $this->assertSame('.. include:: /Includes.rst.txt' . PHP_EOL, $output[0]);
     }
 
     /**


### PR DESCRIPTION
This project generates the Fluid view helper documentation for the [TYPO3CMS-Reference-ViewHelper](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-ViewHelper) project. Merge the PRs in both projects related to new documentation standards at the same time.

Test these changes with
``` bash
git clone --branch "task-update-docs" git@github.com:TYPO3-Documentation/fluid-documentation-generator.git
cd fluid-documentation-generator
composer install
vendor/bin/phpunit
```

Relates: https://github.com/TYPO3-Documentation/T3DocTeam/issues/181