### PR TITLE
[TASK] Parse ViewHelper Markdown description for reST export

### DIFF
--- a/resources/templates/Default/ViewHelper.rst
+++ b/resources/templates/Default/ViewHelper.rst
@@ -7,7 +7,7 @@
 {headlineDecoration}
 
 
-{viewHelper.description -> f:format.raw()}
+{viewHelper.descriptionAsRst -> f:format.raw()}
 
 Arguments
 =========

--- a/src/ViewHelperDocumentation.php
+++ b/src/ViewHelperDocumentation.php
@@ -114,7 +114,7 @@ class ViewHelperDocumentation
                 return $matches[1] . PHP_EOL . str_repeat('-', strlen($matches[1]));
             },
             // Code block
-            '/\\n\\n```\S*\\n([^`]*)```/s' => function ($matches) {
+            '/\\n\\n```\S*\\n(.*?)```/s' => function ($matches) {
                 return PHP_EOL . PHP_EOL . '::' . PHP_EOL. PHP_EOL .
                     implode(PHP_EOL, array_map(function ($line) {
                         return '    ' . $line;

--- a/tests/Fixtures/rendering/input/fluidtypo3/vhs/6.1/schema.xsd
+++ b/tests/Fixtures/rendering/input/fluidtypo3/vhs/6.1/schema.xsd
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://typo3.org/ns/FluidTYPO3/Vhs/ViewHelpers">
+    <xsd:element name="format.dateRange">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[### Date range calculation/formatting ViewHelper
+
+Uses DateTime and DateInterval operations to calculate a range
+between two DateTimes.
+
+#### Usages
+
+- As formatter, the ViewHelper can output a string value such as
+  "2013-04-30 - 2013-05-30" where you can configure both the start
+  and end date (or their common) formats as well as the "glue"
+  which binds the two dates together.
+- As interval calculator, the ViewHelper can be used with a special
+  "intervalFormat" which is a string used in the constructor method
+  for the DateInterval class - for example, "P3M" to add three months.
+  Used this way, you can specify the start date (or rely on the
+  default "now" DateTime) and specify the "intervalFormat" to add
+  your desired duration to your starting date and use that as end
+  date. Without the "return" attribute, this mode simply outputs
+  the formatted dates with interval deciding the end date.
+- When used with the "return" attribute you can specify which type
+  of data to return:
+  - if "return" is "DateTime", a single DateTime instance is returned
+    (which is the end date). Use this with a start date to return the
+    DateTime corresponding to "intervalFormat" into the future/past.
+  - if "return" is a string such as "w", "d", "h" etc. the corresponding
+    counter value (weeks, days, hours etc.) is returned.
+  - if "return" is an array of counter IDs, for example ["w", "d"],
+    the corresponding counters from the range are returned as an array.
+
+#### Note about LLL support and array consumers
+
+When used with the "return" attribute and when this attribute is an
+array, the output becomes suitable for consumption by f:translate, v:l
+or f:format.sprintf for example - as the "arguments" attribute:
+
+    <f:translate key="myDateDisplay"
+        arguments="{v:format.dateRange(intervalFormat: 'P3W', return: {0: 'w', 1: 'd'})}"
+    />
+
+Which if "myDateDisplay" is a string such as "Deadline: %d week(s) and
+%d day(s)" would output a result such as "Deadline: 4 week(s) and 2 day(s)".
+
+> Tip: the values returned by this ViewHelper in both array and single
+> value return modes, are also nicely consumable by the "math" suite
+> of ViewHelpers, for example `v:math.division` would be able to divide
+> number of days by two, three etc. to further divide the date range.
+/]]></xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType mixed="true">
+            <xsd:sequence>
+                <xsd:any minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            <xsd:attribute type="xsd:anySimpleType" name="start" default="'now'">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[Start date which can be a DateTime object or a string consumable by DateTime constructor]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:anySimpleType" name="end" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[End date which can be a DateTime object or a string consumable by DateTime constructor]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="intervalFormat" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Interval format consumable by DateInterval]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="format" default="'Y-m-d'">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Date format to apply to both start and end date]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="startFormat" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Date format to apply to start date]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="endFormat" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Date format to apply to end date]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="glue" default="'-'">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Glue string to concatenate dates with]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:boolean" name="spaceGlue" default="true">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[If TRUE glue string is surrounded with whitespace]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:anySimpleType" name="return" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[Return type; can be exactly "DateTime" to return a DateTime instance, a string like "w" or "d" to return weeks, days between the two dates - or an array of w, d, etc. strings to return the corresponding range count values as an array.]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="iterator.column">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[### Iterator Column Extraction ViewHelper
+
+Implementation of `array_column` for Fluid.
+
+Accepts an input iterator/array and creates a new array
+using values from one column and optionally keys from another
+column.
+
+#### Usage examples
+
+```xml
+<!-- Given input array of user data arrays with "name" and "uid" column: -->
+<f:for each="{users -> v:iterator.column(columnKey: 'name', indexKey: 'uid')}" as="username" key="uid">
+    User {username} has UID {uid}.
+</f:for>
+```
+
+The above demonstrates the logic of the ViewHelper, but the
+example itself of course gives the same result as just iterating
+the `users` variable itself and outputting `{user.username}` etc.,
+but the real power of the ViewHelper comes when using it to feed
+other ViewHelpers with data sets:
+
+```xml
+<!--
+Given same input array as above. Idea being that *any* iterator
+can be supported as input for "options".
+-->
+Select user: <f:form.select options="{users -> v:iterator.column(columnKey: 'name', indexKey: 'uid')}" />
+```
+
+```xml
+<!-- Given same input array as above. Idea being to output all user UIDs as CSV -->
+All UIDs: {users -> v:iterator.column(columnKey: 'uid') -> v:iterator.implode()}
+```
+
+```xml
+<!-- Given same input array as above. Idea being to output all unique users' countries as a list: -->
+Our users live in the following countries:
+{users -> v:iterator.column(columnKey: 'countryName')
+    -> v:iterator.unique()
+    -> v:iterator.implode(glue: ' - ')}
+```
+
+Note that the ViewHelper also supports the "as" argument which
+allows you to not return the new array but instead assign it
+as a new template variable - like any other "as"-capable ViewHelper.
+
+#### Caveat
+
+This ViewHelper passes the subject directly to `array_column` and
+as such it *does not support dotted paths in either key argument
+to extract sub-properties*. That means it *does not support Extbase
+enties as input unless you explicitly implemented `ArrayAccess` on
+the model of the entity and even then support is limited to first
+level properties' values without dots in their names*.
+/]]></xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType mixed="true">
+            <xsd:sequence>
+                <xsd:any minOccurs="0" maxOccurs="1"/>
+            </xsd:sequence>
+            <xsd:attribute type="xsd:anySimpleType" name="subject" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[Input to work on - Array/Traversable/...]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="columnKey" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[Name of the column whose values will become the value of the new array]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="indexKey" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[Name of the column whose values will become the index of the new array]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute type="xsd:string" name="as" default="NULL">
+                <xsd:annotation>
+                    <xsd:documentation>
+                        <![CDATA[Template variable name to assign; if not specified the ViewHelper returns the variable instead.]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/tests/Fixtures/rendering/input/fluidtypo3/vhs/6.1/schema.xsd
+++ b/tests/Fixtures/rendering/input/fluidtypo3/vhs/6.1/schema.xsd
@@ -38,9 +38,11 @@ When used with the "return" attribute and when this attribute is an
 array, the output becomes suitable for consumption by f:translate, v:l
 or f:format.sprintf for example - as the "arguments" attribute:
 
-    <f:translate key="myDateDisplay"
-        arguments="{v:format.dateRange(intervalFormat: 'P3W', return: {0: 'w', 1: 'd'})}"
-    />
+```
+<f:translate key="myDateDisplay"
+    arguments="{v:format.dateRange(intervalFormat: 'P3W', return: {0: 'w', 1: 'd'})}"
+/>
+```
 
 Which if "myDateDisplay" is a string such as "Deadline: %d week(s) and
 %d day(s)" would output a result such as "Deadline: 4 week(s) and 2 day(s)".

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
@@ -45,6 +45,8 @@ When used with the "return" attribute and when this attribute is an
 array, the output becomes suitable for consumption by f:translate, v:l
 or f:format.sprintf for example - as the "arguments" attribute:
 
+::
+
     <f:translate key="myDateDisplay"
         arguments="{v:format.dateRange(intervalFormat: 'P3W', return: {0: 'w', 1: 'd'})}"
     />

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
@@ -1,0 +1,191 @@
+.. include:: /Includes.rst.txt
+
+.. _fluidtypo3-vhs-format-daterange:
+
+================
+format.dateRange
+================
+
+
+Date range calculation/formatting ViewHelper
+============================================
+
+Uses DateTime and DateInterval operations to calculate a range
+between two DateTimes.
+
+Usages
+------
+
+- As formatter, the ViewHelper can output a string value such as
+  "2013-04-30 - 2013-05-30" where you can configure both the start
+  and end date (or their common) formats as well as the "glue"
+  which binds the two dates together.
+- As interval calculator, the ViewHelper can be used with a special
+  "intervalFormat" which is a string used in the constructor method
+  for the DateInterval class - for example, "P3M" to add three months.
+  Used this way, you can specify the start date (or rely on the
+  default "now" DateTime) and specify the "intervalFormat" to add
+  your desired duration to your starting date and use that as end
+  date. Without the "return" attribute, this mode simply outputs
+  the formatted dates with interval deciding the end date.
+- When used with the "return" attribute you can specify which type
+  of data to return:
+  - if "return" is "DateTime", a single DateTime instance is returned
+    (which is the end date). Use this with a start date to return the
+    DateTime corresponding to "intervalFormat" into the future/past.
+  - if "return" is a string such as "w", "d", "h" etc. the corresponding
+    counter value (weeks, days, hours etc.) is returned.
+  - if "return" is an array of counter IDs, for example ["w", "d"],
+    the corresponding counters from the range are returned as an array.
+
+Note about LLL support and array consumers
+------------------------------------------
+
+When used with the "return" attribute and when this attribute is an
+array, the output becomes suitable for consumption by f:translate, v:l
+or f:format.sprintf for example - as the "arguments" attribute:
+
+    <f:translate key="myDateDisplay"
+        arguments="{v:format.dateRange(intervalFormat: 'P3W', return: {0: 'w', 1: 'd'})}"
+    />
+
+Which if "myDateDisplay" is a string such as "Deadline: %d week(s) and
+%d day(s)" would output a result such as "Deadline: 4 week(s) and 2 day(s)".
+
+    Tip: the values returned by this ViewHelper in both array and single
+    value return modes, are also nicely consumable by the "math" suite
+    of ViewHelpers, for example `v:math.division` would be able to divide
+    number of days by two, three etc. to further divide the date range.
+
+Arguments
+=========
+
+
+.. _format.daterange_start:
+
+start
+-----
+
+:aspect:`DataType`
+   mixed
+
+:aspect:`Default`
+   'now'
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Start date which can be a DateTime object or a string consumable by DateTime constructor
+
+.. _format.daterange_end:
+
+end
+---
+
+:aspect:`DataType`
+   mixed
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   End date which can be a DateTime object or a string consumable by DateTime constructor
+
+.. _format.daterange_intervalformat:
+
+intervalFormat
+--------------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Interval format consumable by DateInterval
+
+.. _format.daterange_format:
+
+format
+------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Default`
+   'Y-m-d'
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Date format to apply to both start and end date
+
+.. _format.daterange_startformat:
+
+startFormat
+-----------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Date format to apply to start date
+
+.. _format.daterange_endformat:
+
+endFormat
+---------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Date format to apply to end date
+
+.. _format.daterange_glue:
+
+glue
+----
+
+:aspect:`DataType`
+   string
+
+:aspect:`Default`
+   '-'
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Glue string to concatenate dates with
+
+.. _format.daterange_spaceglue:
+
+spaceGlue
+---------
+
+:aspect:`DataType`
+   boolean
+
+:aspect:`Default`
+   true
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   If TRUE glue string is surrounded with whitespace
+
+.. _format.daterange_return:
+
+return
+------
+
+:aspect:`DataType`
+   mixed
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Return type; can be exactly "DateTime" to return a DateTime instance, a string like "w" or "d" to return weeks, days between the two dates - or an array of w, d, etc. strings to return the corresponding range count values as an array.

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/Index.rst
@@ -1,0 +1,34 @@
+.. include:: /Includes.rst.txt
+
+======
+format
+======
+
+
+* 16 ViewHelpers documented
+* 3 Sub namespaces
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   */Index
+   Append
+   Case
+   DateRange
+   Eliminate
+   Hash
+   Hide
+   Markdown
+   Plaintext
+   PregReplace
+   Prepend
+   Replace
+   SanitizeString
+   Substring
+   Tidy
+   Trim
+   WordWrap
+
+
+

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Index.rst
@@ -1,0 +1,25 @@
+.. include:: /Includes.rst.txt
+
+==============
+fluidtypo3/vhs
+==============
+
+* 10 ViewHelpers documented
+* 22 Sub namespaces
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   */Index
+   Asset
+   Call
+   Const
+   Debug
+   L
+   Menu
+   Or
+   Tag
+   Try
+   Unless
+

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Column.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Column.rst
@@ -1,0 +1,124 @@
+.. include:: /Includes.rst.txt
+
+.. _fluidtypo3-vhs-iterator-column:
+
+===============
+iterator.column
+===============
+
+
+Iterator Column Extraction ViewHelper
+=====================================
+
+Implementation of `array_column` for Fluid.
+
+Accepts an input iterator/array and creates a new array
+using values from one column and optionally keys from another
+column.
+
+Usage examples
+--------------
+
+::
+
+    <!-- Given input array of user data arrays with "name" and "uid" column: -->
+    <f:for each="{users -> v:iterator.column(columnKey: 'name', indexKey: 'uid')}" as="username" key="uid">
+        User {username} has UID {uid}.
+    </f:for>
+
+The above demonstrates the logic of the ViewHelper, but the
+example itself of course gives the same result as just iterating
+the `users` variable itself and outputting `{user.username}` etc.,
+but the real power of the ViewHelper comes when using it to feed
+other ViewHelpers with data sets:
+
+::
+
+    <!--
+    Given same input array as above. Idea being that *any* iterator
+    can be supported as input for "options".
+    -->
+    Select user: <f:form.select options="{users -> v:iterator.column(columnKey: 'name', indexKey: 'uid')}" />
+
+::
+
+    <!-- Given same input array as above. Idea being to output all user UIDs as CSV -->
+    All UIDs: {users -> v:iterator.column(columnKey: 'uid') -> v:iterator.implode()}
+
+::
+
+    <!-- Given same input array as above. Idea being to output all unique users' countries as a list: -->
+    Our users live in the following countries:
+    {users -> v:iterator.column(columnKey: 'countryName')
+        -> v:iterator.unique()
+        -> v:iterator.implode(glue: ' - ')}
+
+Note that the ViewHelper also supports the "as" argument which
+allows you to not return the new array but instead assign it
+as a new template variable - like any other "as"-capable ViewHelper.
+
+Caveat
+------
+
+This ViewHelper passes the subject directly to `array_column` and
+as such it *does not support dotted paths in either key argument
+to extract sub-properties*. That means it *does not support Extbase
+enties as input unless you explicitly implemented `ArrayAccess` on
+the model of the entity and even then support is limited to first
+level properties' values without dots in their names*.
+
+Arguments
+=========
+
+
+.. _iterator.column_subject:
+
+subject
+-------
+
+:aspect:`DataType`
+   mixed
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Input to work on - Array/Traversable/...
+
+.. _iterator.column_columnkey:
+
+columnKey
+---------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Name of the column whose values will become the value of the new array
+
+.. _iterator.column_indexkey:
+
+indexKey
+--------
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Name of the column whose values will become the index of the new array
+
+.. _iterator.column_as:
+
+as
+--
+
+:aspect:`DataType`
+   string
+
+:aspect:`Required`
+   false
+:aspect:`Description`
+   Template variable name to assign; if not specified the ViewHelper returns the variable instead.

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Index.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Index.rst
@@ -1,0 +1,44 @@
+.. include:: /Includes.rst.txt
+
+========
+iterator
+========
+
+
+* 28 ViewHelpers documented
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   Chunk
+   Column
+   Diff
+   Explode
+   Extract
+   Filter
+   First
+   For
+   Implode
+   IndexOf
+   Intersect
+   Keys
+   Last
+   Loop
+   Merge
+   Next
+   Pop
+   Previous
+   Push
+   Random
+   Range
+   Reverse
+   Shift
+   Slice
+   Sort
+   Split
+   Unique
+   Values
+
+
+

--- a/tests/Functional/RstRendering/ViewHelperFileWithMarkdownTest.php
+++ b/tests/Functional/RstRendering/ViewHelperFileWithMarkdownTest.php
@@ -1,0 +1,146 @@
+<?php
+declare(strict_types=1);
+
+namespace NamelessCoder\FluidDocumentationGenerator\Tests\Functional\RstRendering;
+
+
+use NamelessCoder\FluidDocumentationGenerator\Data\DataFileResolver;
+use NamelessCoder\FluidDocumentationGenerator\Entity\Schema;
+use NamelessCoder\FluidDocumentationGenerator\Export\RstExporter;
+use NamelessCoder\FluidDocumentationGenerator\SchemaDocumentationGenerator;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\TestCase;
+
+class ViewHelperFileWithMarkdownTest extends TestCase
+{
+    /**
+     * @var vfsStreamDirectory
+     */
+    private $vfs;
+
+    /**
+     * the generated file is compared against this fixture file
+     * @var array
+     */
+    private $fixtureFilePaths = [
+        __DIR__ . '/../../Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst',
+        __DIR__ . '/../../Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Column.rst',
+    ];
+
+    /**
+     * output of the generation process
+     * @var array
+     */
+    private $generatedFilePaths = [
+        'outputDir/public/fluidtypo3/vhs/6.1/Format/DateRange.rst',
+        'outputDir/public/fluidtypo3/vhs/6.1/Iterator/Column.rst',
+    ];
+
+    protected function setUp()
+    {
+        $this->vfs = vfsStream::setup('outputDir');
+        $this->vfs->addChild(vfsStream::newDirectory('cache'));
+        $dataFileResolver = DataFileResolver::getInstance(vfsStream::url('outputDir'));
+        $dataFileResolver->setResourcesDirectory(__DIR__ . '/../../../resources/');
+        $dataFileResolver->setSchemasDirectory(__DIR__ . '/../../Fixtures/rendering/input/');
+        $schemaDocumentationGenerator = new SchemaDocumentationGenerator(
+            [
+                new RstExporter()
+            ]
+        );
+        $schemaDocumentationGenerator->generateFilesForRoot();
+        foreach ($dataFileResolver->resolveInstalledVendors() as $vendor) {
+            $schemaDocumentationGenerator->generateFilesForVendor($vendor);
+            foreach ($vendor->getPackages() as $package) {
+                $schemaDocumentationGenerator->generateFilesForPackage($package);
+                foreach ($package->getVersions() as $version) {
+                    $schemaDocumentationGenerator->generateFilesForSchema(new Schema($version));
+                }
+            }
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function fileIsCreated()
+    {
+        $this->assertTrue($this->vfs->hasChild($this->generatedFilePaths[0]));
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionHeadlineAsExpected()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[0])->url());
+        $index = 9;
+        $this->assertSame('Date range calculation/formatting ViewHelper' . PHP_EOL, $output[$index]);
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionHeadlineIsProperlyDecorated()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[0])->url());
+        $headlineTextIndex = 9;
+        $lengthOfHeadline = strlen($output[$headlineTextIndex]);
+        $this->assertSame($lengthOfHeadline, strlen($output[$headlineTextIndex + 1]));
+        $this->assertRegExp('/^[=]+$/', $output[$headlineTextIndex + 1]);
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionHeadlineLvl2AsExpected()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[0])->url());
+        $index = 15;
+        $this->assertSame('Usages' . PHP_EOL, $output[$index]);
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionHeadlineLvl2IsProperlyDecorated()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[0])->url());
+        $headlineTextIndex = 15;
+        $lengthOfHeadline = strlen($output[$headlineTextIndex]);
+        $this->assertSame($lengthOfHeadline, strlen($output[$headlineTextIndex + 1]));
+        $this->assertRegExp('/^[-]+$/', $output[$headlineTextIndex + 1]);
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionCodeBlockIsProperlyDeclared()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[1])->url());
+        $codeBlockIndex = 23;
+        $this->assertSame('::' . PHP_EOL, $output[$codeBlockIndex-2]);
+    }
+
+    /**
+     * @test
+     */
+    public function descriptionQuotationBlockIsProperlyIndented()
+    {
+        $output = file($this->vfs->getChild($this->generatedFilePaths[0])->url());
+        $codeBlockIndex = 56;
+        $this->assertRegExp('/^    [^\s]/', $output[$codeBlockIndex]);
+    }
+
+    /**
+     * @test
+     */
+    public function generatedFileIsSameAsFixture()
+    {
+        for ($i = 0; $i <= count($this->fixtureFilePaths)-1; $i++) {
+            $this->assertSame(file_get_contents($this->fixtureFilePaths[$i]),
+                file_get_contents($this->vfs->getChild($this->generatedFilePaths[$i])->url()));
+        }
+    }
+}


### PR DESCRIPTION
The ViewHelper description could be in Markdown format: Perform basic parsing in reST.

This parsing is currently tailored to the TYPO3 VHS Extension documentation, which writes its ViewHelpers documentation in Markdown instead of reST. Move the parsing to its own class or use a third-party package if you want it to be more general - or try to convince the project maintainers to always write their ViewHelpers documentation in reST.

Fixes: #4 