### PR TITLE
[BUGFIX] Fix accessing array index with curly braces

### DIFF
--- a/src/Data/DataFileResolver.php
+++ b/src/Data/DataFileResolver.php
@@ -196,7 +196,7 @@ class DataFileResolver
                 $files,
                 function ($item) use ($folderPath)
                 {
-                    return $item{0} !== '.' && is_dir($folderPath . $item);
+                    return $item[0] !== '.' && is_dir($folderPath . $item);
                 }
             )
         );


### PR DESCRIPTION
Array and string offset access syntax with curly
braces is no longer supported.