### PR TITLE
[BUGFIX] Fix wrong Fluid branch name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "namelesscoder/fluid-documentation-generator",
   "require": {
-    "typo3fluid/fluid": "dev-master",
+    "typo3fluid/fluid": "dev-main",
     "php": "^7.1",
     "cebe/markdown": "^1.2"
   },


### PR DESCRIPTION
The main branch was probably renamed from "master" to "main" recently.