### PR TITLE
[!!!][BUGFIX] Resolve duplicate references

### DIFF
--- a/src/Export/RstExporter.php
+++ b/src/Export/RstExporter.php
@@ -153,7 +153,7 @@ class RstExporter implements ExporterInterface
         foreach ($viewHelperDocumentation->getArgumentDefinitions() as $argumentDefinition) {
             $argumentHeadline = trim($argumentDefinition->getName());
             $argumentHeadlineDecoration = array_pad([], strlen($argumentHeadline), '-');
-            $argumentHeadlineIdentifier = strtolower($viewHelperDocumentation->getName() . '_' . $argumentHeadline);
+            $argumentHeadlineIdentifier = strtolower($headlineIdentifier . '-' . $argumentHeadline);
             $argumentsData = [
                 'headline' => $argumentHeadline,
                 'headlineIdentifier' => $argumentHeadlineIdentifier,

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Format/DateRange.rst
@@ -67,7 +67,7 @@ Arguments
 =========
 
 
-.. _format.daterange_start:
+.. _fluidtypo3-vhs-format-daterange-start:
 
 start
 -----
@@ -83,7 +83,7 @@ start
 :aspect:`Description`
    Start date which can be a DateTime object or a string consumable by DateTime constructor
 
-.. _format.daterange_end:
+.. _fluidtypo3-vhs-format-daterange-end:
 
 end
 ---
@@ -96,7 +96,7 @@ end
 :aspect:`Description`
    End date which can be a DateTime object or a string consumable by DateTime constructor
 
-.. _format.daterange_intervalformat:
+.. _fluidtypo3-vhs-format-daterange-intervalformat:
 
 intervalFormat
 --------------
@@ -109,7 +109,7 @@ intervalFormat
 :aspect:`Description`
    Interval format consumable by DateInterval
 
-.. _format.daterange_format:
+.. _fluidtypo3-vhs-format-daterange-format:
 
 format
 ------
@@ -125,7 +125,7 @@ format
 :aspect:`Description`
    Date format to apply to both start and end date
 
-.. _format.daterange_startformat:
+.. _fluidtypo3-vhs-format-daterange-startformat:
 
 startFormat
 -----------
@@ -138,7 +138,7 @@ startFormat
 :aspect:`Description`
    Date format to apply to start date
 
-.. _format.daterange_endformat:
+.. _fluidtypo3-vhs-format-daterange-endformat:
 
 endFormat
 ---------
@@ -151,7 +151,7 @@ endFormat
 :aspect:`Description`
    Date format to apply to end date
 
-.. _format.daterange_glue:
+.. _fluidtypo3-vhs-format-daterange-glue:
 
 glue
 ----
@@ -167,7 +167,7 @@ glue
 :aspect:`Description`
    Glue string to concatenate dates with
 
-.. _format.daterange_spaceglue:
+.. _fluidtypo3-vhs-format-daterange-spaceglue:
 
 spaceGlue
 ---------
@@ -183,7 +183,7 @@ spaceGlue
 :aspect:`Description`
    If TRUE glue string is surrounded with whitespace
 
-.. _format.daterange_return:
+.. _fluidtypo3-vhs-format-daterange-return:
 
 return
 ------

--- a/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Column.rst
+++ b/tests/Fixtures/rendering/output/Documentation/fluidtypo3/vhs/6.1/Iterator/Column.rst
@@ -75,7 +75,7 @@ Arguments
 =========
 
 
-.. _iterator.column_subject:
+.. _fluidtypo3-vhs-iterator-column-subject:
 
 subject
 -------
@@ -88,7 +88,7 @@ subject
 :aspect:`Description`
    Input to work on - Array/Traversable/...
 
-.. _iterator.column_columnkey:
+.. _fluidtypo3-vhs-iterator-column-columnkey:
 
 columnKey
 ---------
@@ -101,7 +101,7 @@ columnKey
 :aspect:`Description`
    Name of the column whose values will become the value of the new array
 
-.. _iterator.column_indexkey:
+.. _fluidtypo3-vhs-iterator-column-indexkey:
 
 indexKey
 --------
@@ -114,7 +114,7 @@ indexKey
 :aspect:`Description`
    Name of the column whose values will become the index of the new array
 
-.. _iterator.column_as:
+.. _fluidtypo3-vhs-iterator-column-as:
 
 as
 --

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/Link/EditRecord.rst
@@ -32,7 +32,7 @@ Arguments
 =========
 
 
-.. _link.editrecord_additionalattributes:
+.. _typo3-backend-link-editrecord-additionalattributes:
 
 additionalAttributes
 --------------------
@@ -45,7 +45,7 @@ additionalAttributes
 :aspect:`Description`
    Additional tag attributes. They will be added directly to the resulting HTML tag.
 
-.. _link.editrecord_data:
+.. _typo3-backend-link-editrecord-data:
 
 data
 ----
@@ -58,7 +58,7 @@ data
 :aspect:`Description`
    Additional data-* attributes. They will each be added with a "data-" prefix.
 
-.. _link.editrecord_class:
+.. _typo3-backend-link-editrecord-class:
 
 class
 -----
@@ -71,7 +71,7 @@ class
 :aspect:`Description`
    CSS class(es) for this element
 
-.. _link.editrecord_dir:
+.. _typo3-backend-link-editrecord-dir:
 
 dir
 ---
@@ -84,7 +84,7 @@ dir
 :aspect:`Description`
    Text direction for this HTML element. Allowed strings: "ltr" (left to right), "rtl" (right to left)
 
-.. _link.editrecord_id:
+.. _typo3-backend-link-editrecord-id:
 
 id
 --
@@ -97,7 +97,7 @@ id
 :aspect:`Description`
    Unique (in this file) identifier for this HTML element.
 
-.. _link.editrecord_lang:
+.. _typo3-backend-link-editrecord-lang:
 
 lang
 ----
@@ -110,7 +110,7 @@ lang
 :aspect:`Description`
    Language for this element. Use short names specified in RFC 1766
 
-.. _link.editrecord_style:
+.. _typo3-backend-link-editrecord-style:
 
 style
 -----
@@ -123,7 +123,7 @@ style
 :aspect:`Description`
    Individual CSS styles for this element
 
-.. _link.editrecord_title:
+.. _typo3-backend-link-editrecord-title:
 
 title
 -----
@@ -136,7 +136,7 @@ title
 :aspect:`Description`
    Tooltip text of element
 
-.. _link.editrecord_accesskey:
+.. _typo3-backend-link-editrecord-accesskey:
 
 accesskey
 ---------
@@ -149,7 +149,7 @@ accesskey
 :aspect:`Description`
    Keyboard shortcut to access this element
 
-.. _link.editrecord_tabindex:
+.. _typo3-backend-link-editrecord-tabindex:
 
 tabindex
 --------
@@ -162,7 +162,7 @@ tabindex
 :aspect:`Description`
    Specifies the tab order of this element
 
-.. _link.editrecord_onclick:
+.. _typo3-backend-link-editrecord-onclick:
 
 onclick
 -------
@@ -175,7 +175,7 @@ onclick
 :aspect:`Description`
    JavaScript evaluated for the onclick event
 
-.. _link.editrecord_uid:
+.. _typo3-backend-link-editrecord-uid:
 
 uid
 ---
@@ -188,7 +188,7 @@ uid
 :aspect:`Description`
    Uid of record to be edited
 
-.. _link.editrecord_table:
+.. _typo3-backend-link-editrecord-table:
 
 table
 -----
@@ -201,7 +201,7 @@ table
 :aspect:`Description`
    Target database table
 
-.. _link.editrecord_returnurl:
+.. _typo3-backend-link-editrecord-returnurl:
 
 returnUrl
 ---------

--- a/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
+++ b/tests/Fixtures/rendering/output/Documentation/typo3/backend/9.4/ModuleLink.rst
@@ -17,7 +17,7 @@ Arguments
 =========
 
 
-.. _modulelink_route:
+.. _typo3-backend-modulelink-route:
 
 route
 -----
@@ -30,7 +30,7 @@ route
 :aspect:`Description`
    The route to link to
 
-.. _modulelink_arguments:
+.. _typo3-backend-modulelink-arguments:
 
 arguments
 ---------
@@ -46,7 +46,7 @@ arguments
 :aspect:`Description`
    Additional link arguments
 
-.. _modulelink_query:
+.. _typo3-backend-modulelink-query:
 
 query
 -----
@@ -59,7 +59,7 @@ query
 :aspect:`Description`
    Additional link arguments as string
 
-.. _modulelink_currenturlparametername:
+.. _typo3-backend-modulelink-currenturlparametername:
 
 currentUrlParameterName
 -----------------------


### PR DESCRIPTION
References for ViewHelper arguments did not contain package information and where therefore not unique. This PR fixes the flaw, however all references to viewhelpers must be changed.