### PR TITLE
[TASK] Limit php cs fixer to paths containing sources

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,11 +1,11 @@
 <?php
 
 $finder = (new PhpCsFixer\Finder())
-    ->in(__DIR__)
-    ->exclude([
-        'docs',
-        'fixtures-local',
-    ]);
+    ->in([
+            __DIR__ . '/src',
+            __DIR__ . '/tests',
+        ]
+    );
 
 return (new PhpCsFixer\Config())
     ->setCacheFile('.cache/.php-cs-fixer.cache')


### PR DESCRIPTION
To prevent vendor, caches etc from being checked