### PR TITLE
[TASK] Simplify ViewHelper crosslinks

### DIFF
--- a/templates/fluidStandalone/ViewHelper.rst
+++ b/templates/fluidStandalone/ViewHelper.rst
@@ -12,10 +12,11 @@
 <f:format.raw>{headline}</f:format.raw>
 {headline -> f:format.raw() -> d:decoration()}
 
+{f:variable(name: 'typo3ViewHelpers', value: 't3viewhelper:Index')}
 ..  note::
     This reference is part of the documentation of Fluid Standalone.
     If you are working with Fluid in TYPO3 CMS, please refer to
-    :ref:`TYPO3's ViewHelper reference <t3viewhelper:Global/{viewHelper.nameWithoutSuffix -> f:replace(search: '\\', replace: '/')}>` instead.
+    :ref:`TYPO3's ViewHelper reference <{typo3ViewHelpers}>` instead.
 
 ..  typo3:viewhelper:: {viewHelperName}
     :source: {jsonFile}


### PR DESCRIPTION
Not all crosslinks work correctly because of namespace merging in TYPO3 core.