### PR TITLE
[TASK] allow justinrainbow/json-schema ^6.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "justinrainbow/json-schema": "^5.2",
+        "justinrainbow/json-schema": "^5.2 || ^6.8",
         "typo3fluid/fluid": "^2.12 || ^4.0 || ^5.0 || dev-main"
     },
     "config": {


### PR DESCRIPTION
This upgrade is required to install the newest version of infection. See: https://github.com/TYPO3/Fluid/pull/1323